### PR TITLE
fix #25: bug: 未正确关闭部分 ssh 连接，持续消耗资源导致系统无法响应

### DIFF
--- a/controller/common.go
+++ b/controller/common.go
@@ -30,7 +30,10 @@ func CheckSSH(c *gin.Context) *ResponseBody {
 		responseBody.Msg = err.Error()
 		return &responseBody
 	}
+
 	err = sshClient.GenerateClient()
+	defer sshClient.Close()
+
 	if err != nil {
 		fmt.Println(err)
 		responseBody.Msg = err.Error()

--- a/controller/file.go
+++ b/controller/file.go
@@ -112,7 +112,7 @@ func UploadFile(c *gin.Context) *ResponseBody {
 		responseBody.Msg = err.Error()
 		return &responseBody
 	}
-	defer sshClient.Sftp.Close()
+	defer sshClient.Close()
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
 		responseBody.Msg = err.Error()
@@ -157,7 +157,7 @@ func DownloadFile(c *gin.Context) *ResponseBody {
 		responseBody.Msg = err.Error()
 		return &responseBody
 	}
-	defer sshClient.Sftp.Close()
+	defer sshClient.Close()
 	if sftpFile, err := sshClient.Download(path); err != nil {
 		fmt.Println(err)
 		responseBody.Msg = err.Error()
@@ -228,7 +228,7 @@ func FileList(c *gin.Context) *ResponseBody {
 		responseBody.Msg = err.Error()
 		return &responseBody
 	}
-	defer sshClient.Sftp.Close()
+	defer sshClient.Close()
 	files, err := sshClient.Sftp.ReadDir(path)
 	if err != nil {
 		if strings.Contains(err.Error(), "exist") {

--- a/core/models.go
+++ b/core/models.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
+	"log"
 	"unicode/utf8"
 )
 
@@ -66,4 +67,32 @@ func NewSSHClient() SSHClient {
 	client.Username = "root"
 	client.Port = 22
 	return client
+}
+
+// Close all closable fields of SSHClient that is opened:
+//
+//	StdinPipe, Session, Sftp, Client
+func (sclient *SSHClient) Close() {
+	defer func() { // just in case
+		if err := recover(); err != nil {
+			log.Println("SSHClient Close recover from panic: ", err)
+		}
+	}()
+
+	if sclient.StdinPipe != nil {
+		sclient.StdinPipe.Close()
+		sclient.StdinPipe = nil
+	}
+	if sclient.Session != nil {
+		sclient.Session.Close()
+		sclient.Session = nil
+	}
+	if sclient.Sftp != nil {
+		sclient.Sftp.Close()
+		sclient.Sftp = nil
+	}
+	if sclient.Client != nil {
+		sclient.Client.Close()
+		sclient.Client = nil
+	}
 }

--- a/core/sshclient.go
+++ b/core/sshclient.go
@@ -121,6 +121,7 @@ func (sclient *SSHClient) Connect(ws *websocket.Conn, timeout time.Duration, clo
 				err := sclient.Session.WindowChange(rows, cols)
 				if err != nil {
 					log.Println(err)
+					close(stopCh)
 					return
 				}
 				continue
@@ -135,13 +136,8 @@ func (sclient *SSHClient) Connect(ws *websocket.Conn, timeout time.Duration, clo
 
 	defer func() {
 		ws.Close()
-		if sclient.Session != nil {
-			sclient.StdinPipe.Close()
-			sclient.Session.Close()
-			sclient.Client.Close()
-			sclient.Session = nil
-			sclient.Client = nil
-		}
+		sclient.Close()
+
 		if err := recover(); err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
解决了 #25

## 问题定位

方法 `func (sclient *SSHClient) GenerateClient() error` 用于真正建立 SSH 连接。

存在有 3 个函数调用该方法：

- `controller/common.go`: `func CheckSSH(...)`
- `controller/terminal.go`: `func TermWs(...)`
- `core/sftpclient.go`: `func (sclient *SSHClient) CreateSftp()`

逐一分析建立的连接（`SSHClient.Client *ssh.Client`）流动和释放情况：

- CheckSSH：未释放。应在该函数结束时 Close。
- TermWs：正确释放。在 core/sshclient.go 中 `func (sclient *SSHClient) Connect(...)` 的 defer 里正确释放。
  - 似乎 resize 的分支也没有释放。
- CreateSftp：不完全释放。在 controller/file.go 的 `UploadFile`、`DownloadFile`、`FileList` 中进行了 `defer sshClient.Sftp.Close()` 但这只释放了 `*sftp.Client`，底层的 `*ssh.Client` 未释放。

## 问题修复

由于 SSHClient 内打包了多个需要释放的对象，但又不是每次都全部使用，容易像上述 sftp 那样遗漏释放。

所以此次更新将 `SSHClient` 的所有可能的 Close 封装到一起，提供一个 `SSHClient.Close()` 方法。

任何调用过 `GenerateClient` 的 `SSHClient` 均要在业务完成后调用 `SSHClient.Close()` 统一关闭所有要关闭的东西。

## 维护注意

任何调用过 `GenerateClient` 的 `SSHClient` 均要在业务完成后调用 `SSHClient.Close()` 统一关闭所有要关闭的东西。

---

close #25 